### PR TITLE
Added ability to zoom further than maxZoom

### DIFF
--- a/app/src/components/LeafletMap-Providers-Control.js
+++ b/app/src/components/LeafletMap-Providers-Control.js
@@ -199,7 +199,8 @@
       if (selected === 'custom' && custom) {
         L.tileLayer(custom, {
             attribution: '',
-            maxZoom: 19
+            maxZoom: 23,
+            maxNativeZoom: 19
         }).addTo(this._map);
 
         return;
@@ -211,12 +212,14 @@
         if (provider.useBing) {
           L.tileLayer.bing(provider.url, {
               attribution: provider.attribute,
-              maxZoom: provider.maxZoom
+              maxZoom: 23,
+              maxNativeZoom: provider.maxZoom
           }).addTo(this._map);
         } else {
           L.tileLayer(provider.url, {
               attribution: provider.attribute,
-              maxZoom: provider.maxZoom
+              maxZoom: 23,
+              maxNativeZoom: provider.maxZoom
           }).addTo(this._map);
         }
       }

--- a/app/src/config.js
+++ b/app/src/config.js
@@ -19,7 +19,7 @@ const config = {
       label: 'Satellite',
       url: 'https://ecn.t{s}.tiles.virtualearth.net/tiles/a{q}.jpeg?g=587&mkt=en-gb&n=z',
       attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors</a>',
-      maxZoom: 19,
+      maxZoom: 20,
       useBing: true
     }
   ],


### PR DESCRIPTION
This allows a user to zoom in further by instructing leaflet to "stretch" the image. This makes it easier to accurately place a GCP on the map.

![image](https://user-images.githubusercontent.com/1951843/39664017-d093e586-504a-11e8-83cc-0164f651f4d4.png)
