### PR TITLE
Removed BOM character on file export, ability to export a GCP file ev…

### DIFF
--- a/app/src/components/ExportModal.js
+++ b/app/src/components/ExportModal.js
@@ -52,7 +52,7 @@ class ExportModal extends Component {
   saveText(evt) {
     evt.preventDefault();
     var blob = new Blob([this.txtarea.value], { type: "text/plain;charset=utf-8" });
-    FileSaver.saveAs(blob, `gcp_file_${Date.now()}.txt`);
+    FileSaver.saveAs(blob, `gcp_file_${Date.now()}.txt`, true);
   }
 
   updateProps(props) {
@@ -73,12 +73,9 @@ class ExportModal extends Component {
       destinationProjection = sourceProjection;
     }
 
-    let error;
-    if (!status.valid) {
-      error = status.errors.map((err, index) => {
+    let error = status.errors.map((err, index) => {
         return <p key={index} dangerouslySetInnerHTML={{ __html: err }} />
       });
-    }
 
     const exportText = this.renderGcpOutput(destinationProjection);
     this.setState({ destinationProjection, error, exportText });

--- a/app/src/components/ImagePanZoom.js
+++ b/app/src/components/ImagePanZoom.js
@@ -530,7 +530,7 @@ class ImagePanZoom extends Component {
               </li>
               {marker.isAutomatic ? (
                 <li>
-                  <a className='action' href='#' onClick={(evt) => {this.onActionLock(evt, marker);}}>Lock</a>
+                  <a className='action' href='#' onClick={(evt) => {this.onActionLock(evt, marker);}}>Deselect</a>
                 </li>
               ) : null}
             </ul>

--- a/app/src/state/utils/controlpoints.js
+++ b/app/src/state/utils/controlpoints.js
@@ -113,15 +113,10 @@ export const relatedPoints = (points, joins, id) => {
 export const validate = (points, joins) => {
   let errors = [];
 
-  if (points.length < 15) {
-    errors.push('A ground control point file must have a minimum of 15 points. There needs to be 5 control objects and each control object must have 3 image points referenced. Please see this <a href="https://github.com/OpenDroneMap/OpenDroneMap/wiki/Running-OpenDroneMap#running-odm-with-ground-control" target="_blank">article</a> for more information.');
-  }
-
-  if (errors.length) {
-    return {
-      valid: false,
-      errors
-    };
+  if (points.length === 0){
+    errors.push('There are no ground control points to export.');
+  }else if (points.length < 15) {
+    errors.push('A ground control point file should have a minimum of 15 points. There needs to be 5 control objects and each control object must have 3 image points referenced. Please see this <a href="https://github.com/OpenDroneMap/OpenDroneMap/wiki/Running-OpenDroneMap#running-odm-with-ground-control" target="_blank">article</a> for more information.');
   }
 
   let mapPoints = points.filter(pt => pt.type === CP_TYPES.MAP);
@@ -130,19 +125,19 @@ export const validate = (points, joins) => {
   let validObjects = joinKeys.filter(d => d.length >= 3);
 
   if (imgPointsLength < 9) {
-    errors.push('Need at least 10 image points.');
+    errors.push('It\'s recommended to have at least 10 image points.');
   }
 
   if (mapPoints.length < 5) {
-    errors.push('Seems you have enough image points but not enough control objects. There must be at least 5.');
+    errors.push('Seems you have enough image points but not enough control objects. There should be at least 5.');
   } else if (joinKeys.length < 5) {
-    errors.push('There must be at least 5 control points that have image points referenced.');
+    errors.push('There should be at least 5 control points that have image points referenced.');
   } else if (validObjects.length < 5) {
-    errors.push('Control objects must have at least 3 image points referenced.');
+    errors.push('Control objects should have at least 3 image points referenced.');
   }
 
   return {
-    valid: errors.length ? false : true,
+    valid: true,
     errors
   }
 };


### PR DESCRIPTION
 - Fixes a problem first reported in https://github.com/OpenDroneMap/WebODM/issues/468 regarding BOM characters being added when pressing the "Save" button.
 - Changes the language of some errors from "must" to "should". Allows a user to export a GCP file even though errors are present. The reason for this is that the rules are a bit strict for certain instances, and it might be beneficial for a user to add less than the recommended number of GCPs for certain datasets.
 - Renames "Lock" to "Deselect" in the popup for a GCP.

cc @smathermather 